### PR TITLE
Fix menu button initialization

### DIFF
--- a/src/scenes/gameOver.js
+++ b/src/scenes/gameOver.js
@@ -79,7 +79,12 @@ class GameOverScene extends Phaser.Scene {
 
     this.menuButton = new Button(
       this,
-      new Button(this, 600, 500, 'blueButton1', 'blueButton2', 'Menu', 'Title'),
+      600,
+      500,
+      'blueButton1',
+      'blueButton2',
+      'Menu',
+      'Title',
     );
   }
 }

--- a/src/scenes/scores.js
+++ b/src/scenes/scores.js
@@ -69,7 +69,12 @@ class ScoresScene extends Phaser.Scene {
 
     this.menuButton = new Button(
       this,
-      new Button(this, 400, 500, 'blueButton1', 'blueButton2', 'Menu', 'Title'),
+      400,
+      500,
+      'blueButton1',
+      'blueButton2',
+      'Menu',
+      'Title',
     );
 
     document.body.appendChild(createTable(this.scores));


### PR DESCRIPTION
## Summary
- simplify GameOverScene menu button parameters
- clean up ScoresScene menu button initialization

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails to build canvas due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6852d56b08e88329a7a146adde90c04b